### PR TITLE
Prelaunch bugfixes

### DIFF
--- a/components/player/index.js
+++ b/components/player/index.js
@@ -24,6 +24,7 @@ export default class Player extends Component {
   }
   onSeekChange = (e) => {
     this.setState({ playedPercent: parseFloat(e.target.value) })
+    this.player.seekTo(parseFloat(e.target.value))
   }
   onSeekMouseUp = (e) => {
     this.setState({ seeking: false })
@@ -61,6 +62,7 @@ export default class Player extends Component {
           alt="play button"
           src={`/${isPlaying ? 'pause' : 'play'}.svg`}
           onClick={togglePlayPause}
+          onKeyDown={(e) => e.key === 'Enter' && togglePlayPause()}
           tabIndex={0}
         />
 
@@ -80,6 +82,7 @@ export default class Player extends Component {
             onMouseDown={this.onSeekMouseDown}
             onChange={this.onSeekChange}
             onMouseUp={this.onSeekMouseUp}
+            onKeyDown={(e) => e.key === 'Enter' && togglePlayPause()}
           />
         </div>
 

--- a/components/story.js
+++ b/components/story.js
@@ -1,6 +1,7 @@
 import { Component } from 'react'
 import { format, parseISO } from 'date-fns'
 import Router from 'next/router'
+import { debounce } from 'lodash'
 
 import Images from './images'
 
@@ -63,9 +64,15 @@ const StoryDetails = ({ story, isPlaying, onPlayClick, onClick }) => (
 class Story extends Component {
   render() {
     const { story, showDetails, isPlaying, onClick, onPlayClick } = this.props
+    const debounceStoryClick = debounce(() => onClick(story), 200)
     return (
       <div className="story">
-        <div className="story-main" onFocus={() => onClick(story)} tabIndex={0}>
+        <div
+          className="story-main"
+          onFocus={debounceStoryClick}
+          onClick={debounceStoryClick}
+          tabIndex={0}
+        >
           <span className="author">{story.author}</span>
 
           <span className="date">

--- a/components/story.js
+++ b/components/story.js
@@ -16,6 +16,8 @@ const StoryDetails = ({ story, isPlaying, onPlayClick, onClick }) => (
         alt="play button"
         src={`/${isPlaying ? 'pause' : 'play'}.svg`}
         onClick={() => onPlayClick(story)}
+        onKeyDown={(e) => e.key === 'Enter' && onPlayClick(story)}
+        tabIndex={0}
       />
     )}
 
@@ -95,6 +97,7 @@ class Story extends Component {
                       `/series/${story.series.seriesName}`
                     )
                   }}
+                  onFocus={(e) => e.stopPropagation()}
                 >
                   {story.series.seriesName}
                 </button>

--- a/lib/strapi-query.js
+++ b/lib/strapi-query.js
@@ -88,7 +88,22 @@ export const getStoryBySlug = async (slug) => {
   return story.data[0]
 }
 
-export const getSearchQueryString = (query) => {
+export const getSearchQueryString = (query, page, limitPerPage) => {
+  if (!query) return ''
+  const start = limitPerPage * page
+  const searchFields = ['title', 'body', 'author', 'description', 'location']
+  const queryString = qs.stringify({
+    _where: {
+      _or: searchFields.map((field) => ({ [`${field}_contains`]: query })),
+    },
+    _sort: 'date:DESC',
+    _start: start,
+    _limit: limitPerPage,
+  })
+  return `?${queryString}`
+}
+
+export const getSearchCountQueryString = (query) => {
   if (!query) return ''
   const searchFields = ['title', 'body', 'author', 'description', 'location']
   const queryString = qs.stringify({
@@ -99,10 +114,12 @@ export const getSearchQueryString = (query) => {
   return `?${queryString}`
 }
 
-export const getStoriesBySearch = async (query) => {
+export const getStoriesBySearch = async (query, page, limitPerPage) => {
   if (!query) return []
   const storiesUrl =
-    api.baseUrl + api.endpoints.stories + getSearchQueryString(query)
+    api.baseUrl +
+    api.endpoints.stories +
+    getSearchQueryString(query, page, limitPerPage)
   const stories = await axios.get(storiesUrl)
   return stories.data
 }
@@ -110,7 +127,7 @@ export const getStoriesBySearch = async (query) => {
 export const countStoriesBySearch = async (query) => {
   if (!query) return -1
   const storiesUrl =
-    api.baseUrl + api.endpoints.countStories + getSearchQueryString(query)
+    api.baseUrl + api.endpoints.countStories + getSearchCountQueryString(query)
   const stories = await axios.get(storiesUrl)
   return stories.data
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kchung.news",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
@@ -10,6 +10,7 @@
       "dependencies": {
         "axios": "^0.21.1",
         "date-fns": "^2.17.0",
+        "lodash.debounce": "^4.0.8",
         "next": "^10.0.6",
         "qs": "^6.10.1",
         "react": "^16.14.0",
@@ -2881,6 +2882,11 @@
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
+    },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -6894,6 +6900,11 @@
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
+    },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
     "lodash.merge": {
       "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "kchung.news",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "dependencies": {
     "axios": "^0.21.1",
     "date-fns": "^2.17.0",
+    "lodash.debounce": "^4.0.8",
     "next": "^10.0.6",
     "qs": "^6.10.1",
     "react": "^16.14.0",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -17,9 +17,10 @@ function KchungNewsApp({ Component, pageProps }) {
   const { url: audioUrl } = audio
 
   const handleStoryClick = (story) => {
-    setOpenStory((prevOpenStory) =>
-      prevOpenStory?.id !== story.id ? story : { id: '' }
-    )
+    setOpenStory((prevOpenStory) => {
+      console.log(story)
+      return prevOpenStory?.id !== story.id ? story : { id: '' }
+    })
   }
 
   const handleStoryPlayClick = (story) => {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -18,7 +18,7 @@ function KchungNewsApp({ Component, pageProps }) {
 
   const handleStoryClick = (story) => {
     setOpenStory((prevOpenStory) =>
-      prevOpenStory?.id !== story.id ? story : null
+      prevOpenStory?.id !== story.id ? story : { id: '' }
     )
   }
 

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -17,10 +17,9 @@ function KchungNewsApp({ Component, pageProps }) {
   const { url: audioUrl } = audio
 
   const handleStoryClick = (story) => {
-    setOpenStory((prevOpenStory) => {
-      console.log(story)
-      return prevOpenStory?.id !== story.id ? story : { id: '' }
-    })
+    setOpenStory((prevOpenStory) =>
+      prevOpenStory?.id !== story.id ? story : { id: '' }
+    )
   }
 
   const handleStoryPlayClick = (story) => {

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react'
 import StoryList from '../components/hoc/story-list'
 import Page from '../components/hoc/page'
-import { findStories, countStories } from '../lib/strapi-query'
+import { countStories } from '../lib/strapi-query'
 import config from '../config'
 
 function StoriesPage({
@@ -24,7 +24,6 @@ function StoriesPage({
       playingStory={playingStory}
       onStoryClick={onStoryClick}
       onPlayClick={onPlayClick}
-      findStories={findStories}
       countStories={countStories}
     />
   )

--- a/pages/search.js
+++ b/pages/search.js
@@ -30,7 +30,7 @@ function SearchPage({
 
   const findAndSetStories = async () => {
     setNumStories(await countStoriesBySearch(query))
-    let response = await getStoriesBySearch(query)
+    let response = await getStoriesBySearch(query, page - 1, LIMIT_PER_PAGE)
     setStories(response)
     setIsLoading(false)
   }

--- a/pages/series.js
+++ b/pages/series.js
@@ -3,6 +3,7 @@ import Page from '../components/hoc/page'
 import Router from 'next/router'
 import { getSeriesList } from '../lib/strapi-query'
 import config from '../config'
+import debounce from 'lodash.debounce'
 
 function BrowseSeriesPage({ setPageTitle, setPageDescription }) {
   const [isLoading, setIsLoading] = useState(true)
@@ -54,9 +55,15 @@ function SeriesList({ series, openSeries, onSeriesClick }) {
 }
 
 function Series({ series, openSeries, onClick }) {
+  const debounceSeriesClick = debounce(() => onClick(series), 200)
   return (
     <div className="series">
-      <div className="series-main" onFocus={() => onClick(series)} tabIndex={0}>
+      <div
+        className="series-main"
+        onFocus={debounceSeriesClick}
+        onClick={debounceSeriesClick}
+        tabIndex={0}
+      >
         <span className="name">{series.seriesName}</span>
       </div>
       {openSeries?.id === series.id && (

--- a/pages/story/[story].js
+++ b/pages/story/[story].js
@@ -44,6 +44,7 @@ function StoryPage({
             alt="play button"
             src={`/${isThisStoryPlaying ? 'pause' : 'play'}.svg`}
             onClick={() => onPlayClick(story)}
+            onKeyDown={(e) => e.key === 'Enter' && onPlayClick(story)}
             tabIndex={0}
           />
         )}


### PR DESCRIPTION
Adds some additional keyboard navigation functionality:
- Seeking with arrow keys in player
- Pressing enter on any play button will toggle play/pause
- Stops onFocus bubbling when tabbing onto a 'Series' button in a story headline

Fixes bug associated with clicking a single story's headline multiple times:
- Now uses both onFocus and onClick for expanding a story, debounces within 200ms. This is to get the tab-focus functionality for expanding a story, but also be able to click a story and have it expand/collapse even when it's focused.

Fixes pagination for search page
- Pagination would show same content on every page now it's actually working